### PR TITLE
move separate_sets to utils

### DIFF
--- a/mahjong/utils.py
+++ b/mahjong/utils.py
@@ -1,5 +1,9 @@
+from typing import DefaultDict
 import math
+import copy
 from enum import Enum
+
+from .components import Tile, Suit
 
 
 def get_values(en: Enum):
@@ -24,3 +28,50 @@ def is_yaochuu(suit: int, rank: int) -> bool:
             return True
 
     return False
+
+
+def separate_sets(hand: DefaultDict[int, int], huro_count: int):
+    """Helper function for seperating player's remaining hands into sets.
+    It should either be 14, 11, 8, 5, or 2 tiles.
+    Note that there's priority for koutsu over shuntsu,
+    so might not be useful for yaku types like 混老頭, 清老頭, etc
+    """
+
+    for possible_jantou in hand.keys():
+        if hand[possible_jantou] >= 2:  # try using it as jantou
+            remain_tiles = copy.deepcopy(hand)
+            remain_tiles[possible_jantou] -= 2
+
+            koutsu = []
+            shuntsu = []
+            sets_to_find = 4 - huro_count
+            for tile_index in sorted(remain_tiles.keys()):
+                if tile_index < Tile(Suit.MANZU.value, 1).index:
+                    if remain_tiles[tile_index] == 3:
+                        sets_to_find -= 1
+                        koutsu.append(Tile.from_index(tile_index))
+                else:  # numbered tiles
+                    if remain_tiles[tile_index] >= 3:  # check for Koutsu
+                        remain_tiles[tile_index] -= 3
+                        sets_to_find -= 1
+                        koutsu.append(Tile.from_index(tile_index))
+                    if remain_tiles[tile_index + 2] > 0:  # check for Shuntsu
+                        chii_n = min(
+                            remain_tiles[tile_index],
+                            remain_tiles[tile_index + 1],
+                            remain_tiles[tile_index + 2]
+                        )
+                        if chii_n > 0:
+                            remain_tiles[tile_index] -= chii_n
+                            remain_tiles[tile_index + 1] -= chii_n
+                            remain_tiles[tile_index + 2] -= chii_n
+                            sets_to_find -= chii_n
+                            for _ in range(chii_n):
+                                shuntsu.append([
+                                    Tile.from_index(tile_index),
+                                    Tile.from_index(tile_index) + 1,
+                                    Tile.from_index(tile_index) + 2
+                                ])
+            if sets_to_find == 0:
+                return koutsu, shuntsu, Tile.from_index(possible_jantou)
+    return None

--- a/mahjong/yaku_types.py
+++ b/mahjong/yaku_types.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from abc import ABC, abstractmethod
 
 from .player import Player
-from .utils import is_yaochuu
+from .utils import is_yaochuu, separate_sets
 from .components import Suit, Jihai, Tile, Naki
 from .naki_and_actions import check_tenpai
 
@@ -78,43 +78,6 @@ class YakuTypes(ABC):
                     fu += 16
                 else: fu += 8
 
-        def separate_sets(hand: DefaultDict[int, int], huro_count: int):
-
-            for possible_jantou in hand.keys():
-                if hand[possible_jantou] >= 2: # try using it as jantou
-                    remain_tiles = copy.deepcopy(hand)
-                    remain_tiles[possible_jantou] -= 2
-                    
-                    koutsu = []
-                    shuntsu = []
-                    sets_to_find = 4 - huro_count
-                    for tile_index in sorted(remain_tiles.keys()):
-                        if tile_index < Tile(Suit.MANZU.value, 1).index:  # only check Koutsu
-                            if remain_tiles[tile_index] == 3:
-                                sets_to_find -= 1
-                                koutsu.append(Tile.from_index(tile_index))
-                        else:  # numbered tiles
-                            if remain_tiles[tile_index] >= 3:  # check for Koutsu
-                                remain_tiles[tile_index] -= 3
-                                sets_to_find -= 1
-                                koutsu.append(Tile.from_index(tile_index))
-                            if remain_tiles[tile_index + 2] > 0:  # check for Shuntsu
-                                chii_n = min(remain_tiles[tile_index],
-                                            remain_tiles[tile_index + 1],
-                                            remain_tiles[tile_index + 2])
-                                if chii_n > 0:
-                                    remain_tiles[tile_index] -= chii_n
-                                    remain_tiles[tile_index + 1] -= chii_n
-                                    remain_tiles[tile_index + 2] -= chii_n
-                                    sets_to_find -= chii_n
-                                    for _ in range(chii_n):
-                                        shuntsu.append([
-                                            Tile.from_index(tile_index),
-                                            Tile.from_index(tile_index) + 1,
-                                            Tile.from_index(tile_index) + 2
-                                        ])
-                    if sets_to_find == 0:
-                        return koutsu, shuntsu, Tile.from_index(possible_jantou)
 
         def calc_wait_pattern_fu(ankous: List[Tile],
                                  shuntsus: List[Tile],


### PR DESCRIPTION
# Description

Changes proposed in this pull request: Move `separate_sets()` from `yaku_types.py` to `utils.py`

Related PRs: #65, #66 

Request reviews from: @

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation

