### PR TITLE
Fix riichi

### DIFF
--- a/mahjong/components.py
+++ b/mahjong/components.py
@@ -169,8 +169,8 @@ class Stack:
         self.uradoras = []
 
         self.initiate()
-        self.playling_wall = iter(self.stack[:122])
-        self.rinshanpai = iter(self.stack[-4:][::-1])  # 王牌是最後七墩，嶺上牌是槓可以抽的最後四張
+        self.playling_wall = self.stack[:122].copy()
+        self.rinshanpai = self.stack[-4:][::-1].copy()  # 王牌是最後七墩，嶺上牌是槓可以抽的最後四張
 
     def initiate(self):
         for suit in range(0, 4):
@@ -184,8 +184,8 @@ class Stack:
 
     def draw(self, from_rinshan: bool = False) -> Tile:
         if from_rinshan:
-            return next(self.rinshanpai)
-        return next(self.playling_wall)
+            return self.rinshanpai.pop(0)
+        return self.playling_wall.pop(0)
 
     def add_dora_indicator(self):
         if len(self.doras) < 5:

--- a/mahjong/naki_and_actions.py
+++ b/mahjong/naki_and_actions.py
@@ -2,7 +2,7 @@ import copy
 from typing import List, DefaultDict, TYPE_CHECKING
 from itertools import groupby
 
-from .components import Tile, Suit, Naki, Huro
+from .components import Tile, Stack, Suit, Naki, Huro
 if TYPE_CHECKING:
     from .player import Player
 
@@ -202,17 +202,31 @@ def check_chii(hand: DefaultDict[int, int],
     return possible_sets
 
 
-def check_riichi(kabe: List[Huro], machi: List[Tile]) -> bool:
+def check_riichi(player: 'Player', machi: List[Tile], stack: Stack) -> bool:
     """Helper function to check if player can declare riichi
+    Conditions:
+    1. menzenchin (可以暗槓，但如果所暗杠的牌可以重组成顺子（包括听的牌）则不能暗杠。)
+    2. machi
+    3. at least 1,000 points
+    4. at least 4 tiles left to draw in playling wall
 
     Args:
         player (Player): Current player, 手牌 副露 棄牌
         machi (List of Tile): Every possible tile that could complete the hand
+        stack (Stack): to count remaining tiles in playling wall
 
     Returns:
         bool: True for opportunity to declare riichi, False otherwise.
     """
-    return not kabe and len(machi) > 0
+    if (
+        player.menzenchin
+        and machi
+        and player.points >= 1_000
+        and len(stack.playling_wall) >= 4
+    ):
+        return True
+
+    return False
 
 
 def check_tenpai(hand: DefaultDict, kabe: List[Huro]) -> List[Tile]:

--- a/mahjong/yaku_types.py
+++ b/mahjong/yaku_types.py
@@ -209,14 +209,10 @@ class JouKyouYaku(YakuTypes):
         1 han
         http://arcturus.su/wiki/Haitei_raoyue_and_houtei_raoyui
         """
-        if not self.is_ron:
-            try:
-                self.stack.draw()
-            except StopIteration:
-                # no more tile
-                self.total_yaku = 'houtei_raoyui'
-                self.total_han = 1
-                return True
+        if not self.is_ron and len(self.stack.playling_wall) == 0:
+            self.total_yaku = 'houtei_raoyui'
+            self.total_han = 1
+            return True
         return False
 
     def riichi(self):  # 立直
@@ -242,13 +238,10 @@ class JouKyouYaku(YakuTypes):
         1 han
         http://arcturus.su/wiki/Haitei_raoyue_and_houtei_raoyui
         """
-        if self.is_ron:
-            try:
-                self.stack.draw()
-            except StopIteration:
-                self.total_yaku = 'haitei_raoyue'
-                self.total_han = 1
-                return True
+        if self.is_ron and len(self.stack.playling_wall) == 0:
+            self.total_yaku = 'haitei_raoyue'
+            self.total_han = 1
+            return True
         return False
 
     def rinshan_kaihou(self):  # 嶺上開花

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -96,9 +96,9 @@ class TestStack(unittest.TestCase):
         self.assertEqual(len(self.test_stack.dora_indicators), 1)
         self.assertEqual(len(self.test_stack.doras), 1)
         self.assertEqual(len(self.test_stack.uradoras), 1)
-        self.assertEqual(next(self.test_stack.playling_wall),
+        self.assertEqual(self.test_stack.draw(),
                          self.test_stack.stack[0])
-        self.assertEqual(next(self.test_stack.rinshanpai),
+        self.assertEqual(self.test_stack.draw(from_rinshan=True),
                          self.test_stack.stack[-1])
 
     def test_add_dora(self):

--- a/tests/test_naki_and_actions.py
+++ b/tests/test_naki_and_actions.py
@@ -1,6 +1,6 @@
 import unittest
 
-from mahjong.components import Tile, Suit, Jihai, Naki, Huro
+from mahjong.components import Tile, Stack, Suit, Jihai, Naki, Huro
 from mahjong.player import Player
 from mahjong.naki_and_actions import (
     check_ron, check_tsumo, check_furiten, check_own_discard_furiten,
@@ -527,23 +527,18 @@ class TestRiichi(unittest.TestCase):
     def setUp(self):
         # tenpai: 3 MANZU 5 SOUZU
         self.player = Player('test', 1)
-        self.player.hand[Tile(Suit.PINZU.value, 1).index] += 1
-        self.player.hand[Tile(Suit.PINZU.value, 2).index] += 1
-        self.player.hand[Tile(Suit.PINZU.value, 3).index] += 1
-        self.player.hand[Tile(Suit.PINZU.value, 4).index] += 1
-        self.player.hand[Tile(Suit.PINZU.value, 5).index] += 1
-        self.player.hand[Tile(Suit.PINZU.value, 6).index] += 1
-        self.player.hand[Tile(Suit.PINZU.value, 7).index] += 1
-        self.player.hand[Tile(Suit.PINZU.value, 8).index] += 1
-        self.player.hand[Tile(Suit.PINZU.value, 9).index] += 1
+        for i in range(1, 10):
+            self.player.hand[Tile(Suit.PINZU.value, i).index] += 1
         self.player.hand[Tile(Suit.MANZU.value, 3).index] += 2
         self.player.hand[Tile(Suit.SOUZU.value, 5).index] += 2
+        self.stack = Stack()
 
     def test_riichi(self):
         machi = check_tenpai(self.player.hand, self.player.kabe)
-        self.assertEqual(check_riichi(self.player.kabe, machi), True)
+        riichi = check_riichi(self.player, machi, self.stack)
+        self.assertEqual(riichi, True)
 
-    def test_no_riichi(self):
+    def test_no_riichi_kabe(self):
         self.player.hand[Tile(Suit.PINZU.value, 1).index] -= 1
         self.player.hand[Tile(Suit.SOUZU.value, 5).index] -= 2
         naki_tile = Tile(Suit.SOUZU.value, 5)
@@ -552,9 +547,18 @@ class TestRiichi(unittest.TestCase):
             Huro(Naki.PON,
                  naki_tile,
                  [Tile(Suit.SOUZU.value, 5) for i in range(3)]))
+        self.player.menzenchin = False
 
         machi = check_tenpai(self.player.hand, self.player.kabe)
-        self.assertEqual(check_riichi(self.player.kabe, machi), False)
+        riichi = check_riichi(self.player, machi, self.stack)
+        self.assertEqual(riichi, False)
+
+    def test_riichi_stack(self):
+        for i in range(120):
+            _ = self.stack.draw()
+        machi = check_tenpai(self.player.hand, self.player.kabe)
+        riichi = check_riichi(self.player, machi, self.stack)
+        self.assertEqual(riichi, False)
 
 
 class TestRemainsAreSets(unittest.TestCase):

--- a/tests/test_naki_and_actions.py
+++ b/tests/test_naki_and_actions.py
@@ -592,5 +592,3 @@ class TestRemainsAreSets(unittest.TestCase):
         huro_count = len(self.player_1.kabe)
         self.assertEqual(
             check_remains_are_sets(remain_tiles, huro_count), False)
-
-


### PR DESCRIPTION
# Description

Fix `check_riichi()` to meet the following 4 conditions:

1. menzenchin (可以暗槓，但如果所暗杠的牌可以重组成顺子（包括听的牌）则不能暗杠。)
2. at least one machi tile
3. at least 1,000 points
4. at least 4 tiles left to draw in playling wall

Change `playling_wall` and `rinshanpai` in `Stack` to List

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the tests and make sure they pass
- [x] I have added tests that prove my fix is effective or that my feature works


```
Ran 125 tests in 0.563s

Name                             Stmts   Miss  Cover
----------------------------------------------------
mahjong/__init__.py                  0      0   100%
mahjong/components.py              172     11    94%
mahjong/game.py                     35     11    69%
mahjong/helpers.py                  56      0   100%
mahjong/kyoku.py                   184     56    70%
mahjong/naki_and_actions.py        129      4    97%
mahjong/player.py                  100     26    74%
mahjong/utils.py                     8      0   100%
tests/__init__.py                    0      0   100%
tests/test_components.py           129      0   100%
tests/test_game.py                  33      0   100%
tests/test_helpers.py               70      0   100%
tests/test_naki_and_actions.py     411      0   100%
tests/test_player.py                84      0   100%
tests/test_points.py                58      0   100%
tests/test_turn.py                 293      0   100%
tests/test_utils.py                 13      0   100%
----------------------------------------------------
TOTAL                             1775    108    94%
```