### PR TITLE
Remove huro from player hand after adding to kabe

### DIFF
--- a/mahjong/player.py
+++ b/mahjong/player.py
@@ -154,11 +154,18 @@ class Player:
     def action_with_naki(self, naki: Naki) -> None:
         # add tmp_huro to kabe
         self.kabe.append(self.tmp_huro)
-        # TODO: remove the huro tiles from player hand
+        self.remove_huro_tiles()
         if naki != Naki.ANKAN:
             self.menzenchin = False
         self.tmp_huro = None
         return
+
+    def remove_huro_tiles(self) -> None:
+        """Remove the called tiles from player's hand.
+        """
+        for tile in self.tmp_huro.tiles:
+            if tile != self.tmp_huro.naki_tile:
+                self.hand[tile.index] -= 1
 
     def discard_after_naki(self) -> Tile:
         discard = self.get_discard()

--- a/tests/test_turn.py
+++ b/tests/test_turn.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import Mock, MagicMock, PropertyMock
 
 from mahjong.player import Player
 from mahjong.components import Stack, Tile, Action, Suit, Naki, Huro
@@ -29,6 +29,14 @@ class TestTurnDrawFlow(unittest.TestCase):
         self.assertEqual(self.turn.draw_flow(self.player_1), (1, None, None))
 
     def test_ankan(self):
+        naki_tile = Tile(Suit.SOUZU.value, 5)
+        naki_tile.owner = self.player_1.seating_position
+        kan = Huro(Naki.ANKAN,
+                   naki_tile,
+                   [Tile(Suit.SOUZU.value, 5) for i in range(4)])
+
+        self.player_1.tmp_huro = kan
+
         self.player_1.action_with_new_tile = MagicMock()
         self.player_1.action_with_new_tile.side_effect = [
             ((Action.NAKI, Naki.CHAKAN), None),
@@ -43,6 +51,15 @@ class TestTurnDrawFlow(unittest.TestCase):
         self.assertEqual(len(self.tile_stack.doras), 2)
 
     def test_chakan(self):
+        # change type from PON to KAN, what's tmp_huro in this case?
+        naki_tile = Tile(Suit.SOUZU.value, 5)
+        naki_tile.owner = self.player_1.seating_position
+        kan = Huro(Naki.ANKAN,
+                   naki_tile,
+                   [Tile(Suit.SOUZU.value, 5) for i in range(4)])
+
+        self.player_1.tmp_huro = kan
+
         self.player_1.action_with_new_tile = MagicMock()
         self.player_1.action_with_new_tile.side_effect = [
             ((Action.NAKI, Naki.CHAKAN), None),
@@ -56,6 +73,14 @@ class TestTurnDrawFlow(unittest.TestCase):
         self.assertEqual(len(self.tile_stack.doras), 2)
 
     def test_chakan_chankan(self):
+        naki_tile = Tile(Suit.SOUZU.value, 5)
+        naki_tile.owner = self.player_1.seating_position
+        kan = Huro(Naki.ANKAN,
+                   naki_tile,
+                   [Tile(Suit.SOUZU.value, 5) for i in range(4)])
+
+        self.player_1.tmp_huro = kan
+
         self.player_1.action_with_new_tile = MagicMock()
         self.player_1.action_with_new_tile.side_effect = [
             ((Action.NAKI, Naki.CHAKAN), None),
@@ -67,6 +92,25 @@ class TestTurnDrawFlow(unittest.TestCase):
         self.assertEqual(discard_pos, None)
 
     def test_ankan_twice(self):
+        naki_tile_1 = Tile(Suit.SOUZU.value, 5)
+        naki_tile_1.owner = self.player_1.seating_position
+        naki_tile_2 = Tile(Suit.SOUZU.value, 6)
+        naki_tile_2.owner = self.player_1.seating_position
+        kan_1 = Huro(Naki.ANKAN,
+                     naki_tile_1,
+                     [Tile(Suit.SOUZU.value, 5) for i in range(4)])
+        kan_2 = Huro(Naki.ANKAN,
+                     naki_tile_2,
+                     [Tile(Suit.SOUZU.value, 6) for i in range(4)])
+
+        self.player_1 = Mock()
+        self.player_1.seating_position = 0
+        self.player_1.get_shimocha = lambda : 1 % 4
+        self.player_1.kawa = []
+        self.player_1.add_kawa = lambda tile: self.player_1.kawa.append(tile)
+        p = PropertyMock(side_effect=[kan_1, kan_2])
+        type(self.player_1).tmp_huro = p
+
         self.player_1.action_with_new_tile = MagicMock()
         self.player_1.action_with_new_tile.side_effect = [
             ((Action.NAKI, Naki.ANKAN), None),
@@ -205,6 +249,13 @@ class TestTurnDrawFlow(unittest.TestCase):
         self.assertEqual(self.turn.check_suukaikan(kabe), False)
 
     def test_rinshan_kaihou(self):
+        naki_tile = Tile(Suit.SOUZU.value, 5)
+        naki_tile.owner = self.player_1.seating_position
+        kan = Huro(Naki.ANKAN,
+                   naki_tile,
+                   [Tile(Suit.SOUZU.value, 5) for i in range(4)])
+
+        self.player_1.tmp_huro = kan
         self.player_1.action_with_new_tile = MagicMock()
         self.player_1.action_with_new_tile.side_effect = [
             ((Action.NAKI, Naki.ANKAN), None),


### PR DESCRIPTION
# Description

Changes proposed in this pull request: 
Before, after adding player.tmp_huro to kabe we forgot to remove the tiles from player's hand

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the tests and make sure they pass
- [x] I have added tests that prove my fix is effective or that my feature works

I need help on fixing the tests @ktc312 !
